### PR TITLE
Improve YouList card layout and button styling

### DIFF
--- a/app-brewery-server/public/project34/styles/main.css
+++ b/app-brewery-server/public/project34/styles/main.css
@@ -65,13 +65,10 @@
 
 .movielist-section {
     display: grid;
-    grid-template-columns: 140px 1fr;
-    grid-template-areas:
-        "Title   Title"
-        "Stars   Stars"
-        "Poster  Details";
+    grid-template-columns: 140px minmax(260px, 1fr);
     gap: 1.5rem;
     padding: 1.5rem;
+    width: min(100%, 760px);
     border-radius: 12px;
     background-color: var(--light-section-bg);
     color: var(--dark-text);
@@ -88,9 +85,7 @@
 
 /* Poster styling */
 .movie-poster {
-    flex: 0 0 150px;
-    /* fixed width for poster */
-    max-width: 150px;
+    max-width: 140px;
     border-radius: 10px;
     overflow: hidden;
 }
@@ -105,8 +100,6 @@
 
 /* Details column */
 .Details {
-    flex: 1;
-    /* remaining space */
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -150,8 +143,9 @@
     margin-top: 0.25rem;
 }
 
-.submit-comment,
-.cancel-comment {
+#submit-comment,
+#cancel-comment,
+.expand-comments {
     padding: 0.4rem 0.8rem;
     border-radius: 6px;
     border: none;
@@ -160,21 +154,23 @@
     transition: background 0.2s ease;
 }
 
-.submit-comment {
+#submit-comment,
+.expand-comments {
     background-color: #03a9f4;
     color: white;
 }
 
-.submit-comment:hover {
+#submit-comment:hover,
+.expand-comments:hover {
     background-color: #06587e;
 }
 
-.cancel-comment {
+#cancel-comment {
     background-color: #ffb76a;
     color: #3a2c1a;
 }
 
-.cancel-comment:hover {
+#cancel-comment:hover {
     background-color: #c56a09;
 }
 
@@ -195,7 +191,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
+    gap: 1rem;
     flex-wrap: wrap;
 }
 
@@ -203,7 +199,7 @@
     padding: 0.5rem;
     border: 1px solid #ccc;
     border-radius: 6px;
-    width: 250px;
+    width: min(70vw, 320px);
 }
 
 .search-button {
@@ -275,6 +271,9 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 1000;
     display: none;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .autocomplete-item {
@@ -312,11 +311,7 @@
    @media (max-width: 768px) {
        .movielist-section {
            grid-template-columns: 1fr;
-           grid-template-areas:
-               "Poster"
-               "Title"
-               "Stars"
-               "Details";
+           justify-items: center;
            text-align: center;
        }
 

--- a/public/js/youlist.js
+++ b/public/js/youlist.js
@@ -125,7 +125,7 @@ dropdown.addEventListener("click", async e => {
         tempCard.dataset.movieId = id;
         tempCard.dataset.type = type;
         tempCard.querySelector("#temp-comment").value = "";
-        tempCard.style.display = "flex";
+        tempCard.style.display = "grid";
     } catch (err) {
         console.error("Item fetch error:", err);
     }


### PR DESCRIPTION
### Motivation
- Make the YouList movie cards more readable and consistent across viewports by constraining card width and tightening the poster/details column layout. 
- Ensure the temporary selected-item card injected by JS renders using the same layout model as the CSS. 
- Fix button selector mismatches so comment controls and the "Show all" control share consistent styling.

### Description
- Adjusted the movie card grid to `grid-template-columns: 140px minmax(260px, 1fr)` and constrained card width with `width: min(100%, 760px)` in `app-brewery-server/public/project34/styles/main.css` to improve readable line-length and poster sizing. 
- Reduced poster max-width to `140px` and simplified the details column to use a flex column layout for predictable spacing. 
- Corrected and unified button selectors so `#submit-comment`, `#cancel-comment`, and `.expand-comments` receive the intended padding, colors, and hover states, and aligned `.expand-comments` with primary action styling. 
- Improved responsiveness and search/autocomplete UX by changing `.search-input` width to `width: min(70vw, 320px)`, resetting list spacing on `.autocomplete-dropdown` with `list-style: none; margin: 0; padding: 0;`, and simplifying mobile rules to center content. 
- Updated `public/js/youlist.js` to set the temporary card display to `grid` (`tempCard.style.display = "grid"`) so the injected card matches the CSS layout.

### Testing
- Ran `node --check public/js/youlist.js` which succeeded. 
- Attempted to start the app with `node index.js`, which failed to boot in this environment due to a missing PostgreSQL connection (`ECONNREFUSED 127.0.0.1:5432`). 
- Attempted an automated Playwright screenshot of `http://127.0.0.1:3000/youlist`, which failed because the server did not start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40932db08832a914c711ccc2a8742)