### PR TITLE
Fix projects page link hitbox alignment

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -588,6 +588,15 @@ body {
   margin-bottom: 5px;
 }
 
+.projects-section.just-in-section li a {
+  display: block;
+  width: 100%;
+}
+
+.projects-section.just-in-section li h3 {
+  margin: 0;
+}
+
 .projects-section.just-in-section h2 {
   margin: 10px 0 0 10px;
 }


### PR DESCRIPTION
### Motivation
- Fix the misaligned/cropped clickable area on the Projects list where inline anchors and default `h3` margins caused the visible text and the link hitbox to not match.

### Description
- Make project list anchors full-row by adding `.projects-section.just-in-section li a { display: block; width: 100%; }` and remove default heading spacing with `.projects-section.just-in-section li h3 { margin: 0; }` so the link hitbox aligns with each row.

### Testing
- Ran `node --check index.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3df34224832abb6d56c0ffff6688)